### PR TITLE
Scaffold VS Code extension with conservative Axon pretty print

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,51 @@
 
 Axon Wrangler is a VS Code extension project for SkySpark Axon: syntax support first, then formatter/pretty-printing, snippets, and diagnostics for common Axon gotchas.
 
-## First Milestone
+## Current v0 Slice
 
-Create a minimal VS Code extension scaffold that recognizes `.axon` files and includes an initial pretty-print command shape. The formatter does not need to understand all Axon yet; v0 should be deliberately conservative and testable.
+This scaffold provides:
+
+- VS Code extension metadata and TypeScript build scripts
+- `.axon` language registration
+- `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
+- a conservative pretty-printer with fixture-based tests
+
+## Pretty-print v0 limits
+
+The formatter is deliberately not a full Axon parser. For now it only:
+
+- trims trailing spaces/tabs from each line
+- normalizes line endings to `\n`
+- ensures exactly one final newline
+
+It does **not** rewrite Axon expressions, infer semantic indentation, parse comments, or connect to SkySpark. If a formatting change would require understanding Axon syntax, v0 should preserve the source text instead.
+
+## Local development
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+Compile:
+
+```sh
+npm run compile
+```
+
+Run fixture tests:
+
+```sh
+npm test
+```
+
+Run in VS Code:
+
+1. Open this repo in VS Code.
+2. Run `npm install` if needed.
+3. Press `F5` to launch an Extension Development Host.
+4. Open or create a `.axon` file.
+5. Run `Axon Wrangler: Pretty Print` from the command palette.
+
+The command formats the current selection when text is selected; otherwise it formats the whole active document.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,22 @@
+{
+  "comments": {
+    "lineComment": "//"
+  },
+  "brackets": [
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"]
+  ],
+  "autoClosingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "[", "close": "]" },
+    { "open": "{", "close": "}" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "surroundingPairs": [
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+    ["\"", "\""]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "axon-wrangler",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axon-wrangler",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^20.14.10",
+        "@types/vscode": "^1.90.0",
+        "typescript": "^5.5.3"
+      },
+      "engines": {
+        "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "axon-wrangler",
+  "displayName": "Axon Wrangler",
+  "description": "Conservative VS Code helpers for SkySpark Axon.",
+  "version": "0.0.1",
+  "publisher": "pipseedai",
+  "private": true,
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Formatters"
+  ],
+  "activationEvents": [
+    "onLanguage:axon",
+    "onCommand:axonWrangler.prettyPrint"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "axon",
+        "aliases": [
+          "Axon",
+          "axon"
+        ],
+        "extensions": [
+          ".axon"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "axonWrangler.prettyPrint",
+        "title": "Axon Wrangler: Pretty Print"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "test": "npm run compile && node --test dist/test/**/*.test.js",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.5.3"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,41 @@
+import * as vscode from "vscode";
+import { prettyPrintAxon } from "./prettyPrint";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand("axonWrangler.prettyPrint", async () => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+      vscode.window.showInformationMessage("Axon Wrangler: open an Axon file before pretty-printing.");
+      return;
+    }
+
+    const document = editor.document;
+    const selection = editor.selection;
+    const targetRange = selection.isEmpty
+      ? fullDocumentRange(document)
+      : new vscode.Range(selection.start, selection.end);
+    const original = document.getText(targetRange);
+    const formatted = prettyPrintAxon(original);
+
+    if (formatted === original) {
+      vscode.window.showInformationMessage("Axon Wrangler: already pretty enough.");
+      return;
+    }
+
+    await editor.edit((editBuilder) => {
+      editBuilder.replace(targetRange, formatted);
+    });
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate(): void {
+  // Nothing to clean up yet.
+}
+
+function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
+  const lastLine = document.lineAt(document.lineCount - 1);
+  return new vscode.Range(new vscode.Position(0, 0), lastLine.range.end);
+}

--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -1,0 +1,17 @@
+/**
+ * Conservative Axon pretty-printer v0.
+ *
+ * This intentionally does not parse Axon. Keep transformations text-preserving
+ * and fixture-backed: remove trailing horizontal whitespace and ensure exactly
+ * one final newline.
+ */
+export function prettyPrintAxon(source: string): string {
+  const withoutTrailingWhitespace = source
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[\t ]+$/u, ""))
+    .join("\n");
+
+  return `${withoutTrailingWhitespace.replace(/\n*$/u, "")}\n`;
+}

--- a/test/fixtures/basic/expected.axon
+++ b/test/fixtures/basic/expected.axon
@@ -1,0 +1,3 @@
+read(site).map(s => do
+  name: s->dis
+end)

--- a/test/fixtures/basic/input.axon
+++ b/test/fixtures/basic/input.axon
@@ -1,0 +1,5 @@
+read(site).map(s => do  
+  name: s->dis  
+end)
+
+

--- a/test/fixtures/preserve-content/expected.axon
+++ b/test/fixtures/preserve-content/expected.axon
@@ -1,0 +1,3 @@
+// keep comment text and quoted spaces
+msg: "  do not trim inside strings  "
+/* block-ish text is untouched by v0 */

--- a/test/fixtures/preserve-content/input.axon
+++ b/test/fixtures/preserve-content/input.axon
@@ -1,0 +1,3 @@
+// keep comment text and quoted spaces
+msg: "  do not trim inside strings  "  
+/* block-ish text is untouched by v0 */

--- a/test/prettyPrint.test.ts
+++ b/test/prettyPrint.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { prettyPrintAxon } from "../src/prettyPrint";
+
+const fixturesRoot = join(process.cwd(), "test", "fixtures");
+
+for (const fixtureName of readdirSync(fixturesRoot)) {
+  test(`prettyPrintAxon fixture: ${fixtureName}`, () => {
+    const input = readFileSync(join(fixturesRoot, fixtureName, "input.axon"), "utf8");
+    const expected = readFileSync(join(fixturesRoot, fixtureName, "expected.axon"), "utf8");
+
+    assert.equal(prettyPrintAxon(input), expected);
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript VS Code extension for Axon Wrangler
- register `.axon` files as the `axon` language
- add `axonWrangler.prettyPrint` for active editor/selection
- implement conservative v0 whitespace-only pretty printing with fixture tests
- document local install/run/test steps and v0 formatter boundaries

Refs #1

## Tests
- npm test

## Notes / deferred
- no full Axon parser
- no semantic indentation rules yet
- no live SkySpark connection