### PR TITLE
feat: add initial Axon syntax grammar and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This scaffold provides:
 
 - VS Code extension metadata and TypeScript build scripts
 - `.axon` language registration
+- conservative TextMate syntax colouring for comments, strings, numbers, refs, keywords/block words, constants, and function-ish calls
+- `samples/basic.axon` as a manual syntax-colour smoke file
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
 - a conservative pretty-printer with fixture-based tests
 
@@ -37,18 +39,39 @@ Compile:
 npm run compile
 ```
 
-Run fixture tests:
+Run tests:
 
 ```sh
 npm test
 ```
 
-Run in VS Code:
+This compiles TypeScript, runs fixture tests for `prettyPrintAxon`, and runs a TextMate tokenization smoke test against `syntaxes/axon.tmLanguage.json`.
+
+## Manual syntax-colour testing
 
 1. Open this repo in VS Code.
 2. Run `npm install` if needed.
 3. Press `F5` to launch an Extension Development Host.
-4. Open or create a `.axon` file.
-5. Run `Axon Wrangler: Pretty Print` from the command palette.
+4. In the Extension Development Host, open `samples/basic.axon` or create another `.axon` file.
+5. Confirm comments, strings, numbers, refs such as `@p:demo-site-123`, block words such as `do`/`end`, constants such as `true`, and function-ish calls such as `read(...)` have visible syntax colouring.
+
+The v0 grammar is intentionally conservative. It does not fully parse Axon or attempt semantic highlighting; it only provides stable TextMate scopes for the obvious lexical shapes covered by the test sample.
+
+## Pretty-print testing
+
+Automated path:
+
+```sh
+npm test
+```
+
+Pretty-print fixture cases live under `test/fixtures/<case>/input.axon` and `expected.axon`. Add a fixture before adding any new formatter rule.
+
+Manual command path:
+
+1. Launch the Extension Development Host with `F5`.
+2. Open a `.axon` document with trailing spaces or extra blank lines at the end.
+3. Run `Axon Wrangler: Pretty Print` from the command palette.
+4. Confirm the current selection is formatted when selected; otherwise the whole document is formatted.
 
 The command formats the current selection when text is selected; otherwise it formats the whole active document.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "devDependencies": {
         "@types/node": "^20.14.10",
         "@types/vscode": "^1.90.0",
-        "typescript": "^5.5.3"
+        "typescript": "^5.5.3",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
       },
       "engines": {
         "vscode": "^1.90.0"
@@ -51,6 +53,20 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "grammars": [
+      {
+        "language": "axon",
+        "scopeName": "source.axon",
+        "path": "./syntaxes/axon.tmLanguage.json"
+      }
+    ],
     "commands": [
       {
         "command": "axonWrangler.prettyPrint",
@@ -47,6 +54,8 @@
   "devDependencies": {
     "@types/node": "^20.14.10",
     "@types/vscode": "^1.90.0",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   }
 }

--- a/samples/basic.axon
+++ b/samples/basic.axon
@@ -1,0 +1,15 @@
+// Axon Wrangler syntax-colour smoke sample
+read(site).map(site => do
+  dis: site->dis
+  id: @p:demo-site-123
+  area: 42.5
+  enabled: true
+  note: "quoted text with \"escape\""
+  if (enabled and area > 10) do
+    debug("large site")
+  else do
+    debug("small site")
+  end
+end)
+
+/* block comments are highlighted conservatively */

--- a/syntaxes/axon.tmLanguage.json
+++ b/syntaxes/axon.tmLanguage.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Axon",
+  "scopeName": "source.axon",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#refs" },
+    { "include": "#numbers" },
+    { "include": "#constants" },
+    { "include": "#keywords" },
+    { "include": "#function-calls" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.axon",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.block.axon",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.axon",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.axon",
+              "match": "\\\\(?:[\\\\\"/bfnrt]|u[0-9A-Fa-f]{4})"
+            }
+          ]
+        }
+      ]
+    },
+    "refs": {
+      "patterns": [
+        {
+          "name": "constant.other.reference.axon",
+          "match": "@[A-Za-z0-9_:.~-]+"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.axon",
+          "match": "(?<![A-Za-z0-9_])-?(?:\\d+\\.\\d+|\\d+)(?:[eE][+-]?\\d+)?(?![A-Za-z0-9_])"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.axon",
+          "match": "\\b(?:true|false|null|na|marker|remove)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.axon",
+          "match": "\\b(?:do|end|if|else|try|catch|throw|return|break|continue)\\b"
+        },
+        {
+          "name": "keyword.operator.word.axon",
+          "match": "\\b(?:and|or|not)\\b"
+        }
+      ]
+    },
+    "function-calls": {
+      "patterns": [
+        {
+          "name": "entity.name.function.axon",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b(?=\\s*\\()"
+        }
+      ]
+    }
+  }
+}

--- a/test/axonGrammar.test.ts
+++ b/test/axonGrammar.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { INITIAL, Registry } from "vscode-textmate";
+import { loadWASM, OnigScanner, OnigString } from "vscode-oniguruma";
+
+const grammarPath = join(process.cwd(), "syntaxes", "axon.tmLanguage.json");
+const wasmPath = require.resolve("vscode-oniguruma/release/onig.wasm");
+
+async function loadAxonGrammar() {
+  await loadWASM(readFileSync(wasmPath).buffer);
+
+  const registry = new Registry({
+    onigLib: Promise.resolve({
+      createOnigScanner: (patterns) => new OnigScanner(patterns),
+      createOnigString: (source) => new OnigString(source),
+    }),
+    loadGrammar: async (scopeName) => {
+      if (scopeName !== "source.axon") {
+        return null;
+      }
+
+      return JSON.parse(readFileSync(grammarPath, "utf8"));
+    },
+  });
+
+  const grammar = await registry.loadGrammar("source.axon");
+  assert.ok(grammar, "source.axon grammar should load");
+  return grammar;
+}
+
+test("Axon TextMate grammar assigns conservative v0 scopes", async () => {
+  const grammar = await loadAxonGrammar();
+  const tokenLines = [
+    grammar.tokenizeLine("// comment", INITIAL),
+    grammar.tokenizeLine("read(site).map(s => do", INITIAL),
+    grammar.tokenizeLine("id: @p:demo-site-123", INITIAL),
+    grammar.tokenizeLine("enabled: true and area > 42.5", INITIAL),
+    grammar.tokenizeLine("note: \"quoted text\"", INITIAL),
+  ];
+
+  const scopedText = tokenLines.flatMap((line, index) => {
+    const source = [
+      "// comment",
+      "read(site).map(s => do",
+      "id: @p:demo-site-123",
+      "enabled: true and area > 42.5",
+      "note: \"quoted text\"",
+    ][index];
+
+    return line.tokens.map((token) => ({
+      text: source.slice(token.startIndex, token.endIndex),
+      scopes: token.scopes,
+    }));
+  });
+
+  assertToken(scopedText, "// comment", "comment.line.double-slash.axon");
+  assertToken(scopedText, "read", "entity.name.function.axon");
+  assertToken(scopedText, "map", "entity.name.function.axon");
+  assertToken(scopedText, "do", "keyword.control.axon");
+  assertToken(scopedText, "@p:demo-site-123", "constant.other.reference.axon");
+  assertToken(scopedText, "true", "constant.language.axon");
+  assertToken(scopedText, "and", "keyword.operator.word.axon");
+  assertToken(scopedText, "42.5", "constant.numeric.axon");
+  assertToken(scopedText, "quoted text", "string.quoted.double.axon");
+});
+
+function assertToken(
+  tokens: Array<{ text: string; scopes: string[] }>,
+  expectedText: string,
+  expectedScope: string,
+): void {
+  assert.ok(
+    tokens.some((token) => token.text === expectedText && token.scopes.includes(expectedScope)),
+    `expected ${JSON.stringify(expectedText)} to include scope ${expectedScope}\n${JSON.stringify(tokens, null, 2)}`,
+  );
+}


### PR DESCRIPTION
## Summary
- adds a conservative v0 Axon TextMate grammar wired into the VS Code extension
- adds `samples/basic.axon` for manual syntax-colour smoke testing
- adds a vscode-textmate/oniguruma tokenization test for comments, strings, numbers, refs, keywords/constants, and function-ish calls
- documents manual syntax-colour testing and automated/manual pretty-print testing paths

Refs #3

## Tests
- npm test

## Deferred
- full Axon parsing / semantic highlighting
- extension-host integration tests for the pretty-print command