### PR TITLE
feat: improve grammar against real Axon sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This scaffold provides:
 
 - VS Code extension metadata and TypeScript build scripts
 - `.axon` language registration
-- conservative TextMate syntax colouring for comments, strings, numbers, refs, keywords/block words, constants, and function-ish calls
-- `samples/basic.axon` as a manual syntax-colour smoke file
+- conservative TextMate syntax colouring for comments, strings, numbers, refs, keywords/block words, constants, operators/arrows, dict/tag keys, and function/method-ish calls
+- `samples/basic.axon` and `samples/real-shape.axon` as syntax-colour smoke files
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
 - a conservative pretty-printer with fixture-based tests
 
@@ -45,17 +45,25 @@ Run tests:
 npm test
 ```
 
-This compiles TypeScript, runs fixture tests for `prettyPrintAxon`, and runs a TextMate tokenization smoke test against `syntaxes/axon.tmLanguage.json`.
+This compiles TypeScript, runs fixture tests for `prettyPrintAxon`, and runs TextMate tokenization tests against `syntaxes/axon.tmLanguage.json`, including the sanitized real-shaped Axon sample.
+
+To run only the syntax-colour tokenization self-test:
+
+```sh
+npm run test:grammar
+```
+
+This verifies emitted TextMate scopes for representative comments, strings, numbers, refs, keywords, chained method/function-ish calls, operators/arrows, dict/tag keys before `:`, and known literals. It does not prove theme colours visually distinguish those scopes; use the manual check below only for final eyeballing in a real VS Code theme.
 
 ## Manual syntax-colour testing
 
 1. Open this repo in VS Code.
 2. Run `npm install` if needed.
 3. Press `F5` to launch an Extension Development Host.
-4. In the Extension Development Host, open `samples/basic.axon` or create another `.axon` file.
-5. Confirm comments, strings, numbers, refs such as `@p:demo-site-123`, block words such as `do`/`end`, constants such as `true`, and function-ish calls such as `read(...)` have visible syntax colouring.
+4. In the Extension Development Host, open `samples/basic.axon`, `samples/real-shape.axon`, or create another `.axon` file.
+5. Confirm the active VS Code theme visibly distinguishes the scoped shapes that `npm run test:grammar` already verifies: comments, strings, numbers, refs such as `@p:demo-site-123`, block words such as `do`/`end`, constants such as `true`/`false`/`null`, operators/arrows such as `=>`/`->`/`==`, dict/tag keys before `:`, and chained method-ish calls such as `.sort(...)`/`.addMeta(...)`/`.toGrid`.
 
-The v0 grammar is intentionally conservative. It does not fully parse Axon or attempt semantic highlighting; it only provides stable TextMate scopes for the obvious lexical shapes covered by the test sample.
+The v0 grammar is intentionally conservative. It does not fully parse Axon or attempt semantic highlighting; it only provides stable TextMate scopes for the obvious lexical shapes covered by the automated tokenization samples. Visual theme contrast remains a manual VS Code check.
 
 ## Pretty-print testing
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "test": "npm run compile && node --test dist/test/**/*.test.js",
+    "test:grammar": "npm run compile && node --test --test-name-pattern \"Axon TextMate grammar\" dist/test/**/*.test.js",
     "vscode:prepublish": "npm run compile"
   },
   "devDependencies": {

--- a/samples/real-shape.axon
+++ b/samples/real-shape.axon
@@ -1,0 +1,20 @@
+// Sanitized Axon-shaped sample from real syntax-colour feedback
+readAll(site and geoCity == "Demo City").sort("dis").toRecList.map(p => do
+  info: {
+    title: p->navName
+    id: @p:demo-site-123
+    dis: p->dis
+    name: p["name"]
+    val: p["curVal"]
+    key: if (p->id != null) p->id else na()
+  }
+
+  grid: readAll(equip and siteRef == p->id)
+    .find(e => e->ahu == true)
+    .addMeta({checked: true, stale: false})
+    .toGrid
+
+  if (grid != null and p["curVal"] >= 10) do
+    return {info: info, grid: grid}
+  end
+end)

--- a/syntaxes/axon.tmLanguage.json
+++ b/syntaxes/axon.tmLanguage.json
@@ -9,6 +9,9 @@
     { "include": "#numbers" },
     { "include": "#constants" },
     { "include": "#keywords" },
+    { "include": "#dict-keys" },
+    { "include": "#operators" },
+    { "include": "#method-calls" },
     { "include": "#function-calls" }
   ],
   "repository": {
@@ -76,11 +79,43 @@
         }
       ]
     },
+    "dict-keys": {
+      "patterns": [
+        {
+          "match": "(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)(\\s*)(:)(?![=])",
+          "captures": {
+            "1": { "name": "variable.parameter.key.axon" },
+            "3": { "name": "punctuation.separator.key-value.axon" }
+          }
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.axon",
+          "match": "=>|->|:=|==|!=|>=|<=|>|<"
+        }
+      ]
+    },
+    "method-calls": {
+      "patterns": [
+        {
+          "match": "(\\.)([A-Za-z_][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": { "name": "punctuation.accessor.dot.axon" },
+            "2": { "name": "entity.name.function.method.axon" }
+          }
+        }
+      ]
+    },
     "function-calls": {
       "patterns": [
         {
-          "name": "entity.name.function.axon",
-          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b(?=\\s*\\()"
+          "match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\b(?=\\s*\\()",
+          "captures": {
+            "1": { "name": "entity.name.function.axon" }
+          }
         }
       ]
     }

--- a/test/axonGrammar.test.ts
+++ b/test/axonGrammar.test.ts
@@ -6,7 +6,10 @@ import { INITIAL, Registry } from "vscode-textmate";
 import { loadWASM, OnigScanner, OnigString } from "vscode-oniguruma";
 
 const grammarPath = join(process.cwd(), "syntaxes", "axon.tmLanguage.json");
+const realShapeSamplePath = join(process.cwd(), "samples", "real-shape.axon");
 const wasmPath = require.resolve("vscode-oniguruma/release/onig.wasm");
+
+type ScopedToken = { text: string; scopes: string[] };
 
 async function loadAxonGrammar() {
   await loadWASM(readFileSync(wasmPath).buffer);
@@ -32,45 +35,71 @@ async function loadAxonGrammar() {
 
 test("Axon TextMate grammar assigns conservative v0 scopes", async () => {
   const grammar = await loadAxonGrammar();
-  const tokenLines = [
-    grammar.tokenizeLine("// comment", INITIAL),
-    grammar.tokenizeLine("read(site).map(s => do", INITIAL),
-    grammar.tokenizeLine("id: @p:demo-site-123", INITIAL),
-    grammar.tokenizeLine("enabled: true and area > 42.5", INITIAL),
-    grammar.tokenizeLine("note: \"quoted text\"", INITIAL),
+  const sourceLines = [
+    "// comment",
+    "read(site).map(s => do",
+    "id: @p:demo-site-123",
+    "enabled: true and area > 42.5",
+    "note: \"quoted text\"",
   ];
+  const scopedText = tokenizeLines(grammar, sourceLines);
 
-  const scopedText = tokenLines.flatMap((line, index) => {
-    const source = [
-      "// comment",
-      "read(site).map(s => do",
-      "id: @p:demo-site-123",
-      "enabled: true and area > 42.5",
-      "note: \"quoted text\"",
-    ][index];
+  assertToken(scopedText, "// comment", "comment.line.double-slash.axon");
+  assertToken(scopedText, "read", "entity.name.function.axon");
+  assertToken(scopedText, "map", "entity.name.function.method.axon");
+  assertToken(scopedText, "=>", "keyword.operator.axon");
+  assertToken(scopedText, "do", "keyword.control.axon");
+  assertToken(scopedText, "id", "variable.parameter.key.axon");
+  assertToken(scopedText, ":", "punctuation.separator.key-value.axon");
+  assertToken(scopedText, "@p:demo-site-123", "constant.other.reference.axon");
+  assertToken(scopedText, "true", "constant.language.axon");
+  assertToken(scopedText, "and", "keyword.operator.word.axon");
+  assertToken(scopedText, ">", "keyword.operator.axon");
+  assertToken(scopedText, "42.5", "constant.numeric.axon");
+  assertToken(scopedText, "quoted text", "string.quoted.double.axon");
+});
 
+test("Axon TextMate grammar scopes real-shaped chained calls, keys, operators, and literals", async () => {
+  const grammar = await loadAxonGrammar();
+  const sampleLines = readFileSync(realShapeSamplePath, "utf8").split(/\r?\n/);
+  const scopedText = tokenizeLines(grammar, sampleLines);
+
+  assertToken(scopedText, "readAll", "entity.name.function.axon");
+  assertToken(scopedText, "sort", "entity.name.function.method.axon");
+  assertToken(scopedText, "toRecList", "entity.name.function.method.axon");
+  assertToken(scopedText, "map", "entity.name.function.method.axon");
+  assertToken(scopedText, "find", "entity.name.function.method.axon");
+  assertToken(scopedText, "addMeta", "entity.name.function.method.axon");
+  assertToken(scopedText, "toGrid", "entity.name.function.method.axon");
+
+  for (const key of ["info", "title", "id", "dis", "name", "val", "key", "grid", "checked", "stale"]) {
+    assertToken(scopedText, key, "variable.parameter.key.axon");
+  }
+
+  for (const operator of ["=>", "->", "==", "!=", ">="]) {
+    assertToken(scopedText, operator, "keyword.operator.axon");
+  }
+
+  assertToken(scopedText, "@p:demo-site-123", "constant.other.reference.axon");
+  assertToken(scopedText, "null", "constant.language.axon");
+  assertToken(scopedText, "true", "constant.language.axon");
+  assertToken(scopedText, "false", "constant.language.axon");
+  assertToken(scopedText, "na", "constant.language.axon");
+  assertToken(scopedText, "10", "constant.numeric.axon");
+  assertToken(scopedText, "curVal", "string.quoted.double.axon");
+});
+
+function tokenizeLines(grammar: Awaited<ReturnType<typeof loadAxonGrammar>>, sourceLines: string[]): ScopedToken[] {
+  return sourceLines.flatMap((source) => {
+    const line = grammar.tokenizeLine(source, INITIAL);
     return line.tokens.map((token) => ({
       text: source.slice(token.startIndex, token.endIndex),
       scopes: token.scopes,
     }));
   });
+}
 
-  assertToken(scopedText, "// comment", "comment.line.double-slash.axon");
-  assertToken(scopedText, "read", "entity.name.function.axon");
-  assertToken(scopedText, "map", "entity.name.function.axon");
-  assertToken(scopedText, "do", "keyword.control.axon");
-  assertToken(scopedText, "@p:demo-site-123", "constant.other.reference.axon");
-  assertToken(scopedText, "true", "constant.language.axon");
-  assertToken(scopedText, "and", "keyword.operator.word.axon");
-  assertToken(scopedText, "42.5", "constant.numeric.axon");
-  assertToken(scopedText, "quoted text", "string.quoted.double.axon");
-});
-
-function assertToken(
-  tokens: Array<{ text: string; scopes: string[] }>,
-  expectedText: string,
-  expectedScope: string,
-): void {
+function assertToken(tokens: ScopedToken[], expectedText: string, expectedScope: string): void {
   assert.ok(
     tokens.some((token) => token.text === expectedText && token.scopes.includes(expectedScope)),
     `expected ${JSON.stringify(expectedText)} to include scope ${expectedScope}\n${JSON.stringify(tokens, null, 2)}`,


### PR DESCRIPTION
## Summary
- expands the conservative TextMate grammar for chained method-ish calls, operators/arrows, dict/tag keys before `:`, and known literals
- adds `samples/real-shape.axon` as a sanitized real-shaped syntax-colour fixture
- extends automated tokenization tests and adds `npm run test:grammar` as the goblin self-test command

Refs #5

## Tests
- `git diff --check`
- `npm run test:grammar`
- `npm test`

## Manual boundary
Automated tests verify emitted TextMate scopes. Final theme contrast / whether scopes are visually distinct in a specific VS Code colour theme still needs manual eyeballing in the Extension Development Host.