### PR TITLE
Polish Haystack tag and bracket access colouring

### DIFF
--- a/samples/real-shape.axon
+++ b/samples/real-shape.axon
@@ -9,10 +9,12 @@ readAll(site and geoCity == "Demo City").sort("dis").toRecList.map(p => do
     key: if (p->id != null) p->id else na()
   }
 
-  grid: readAll(equip and siteRef == p->id)
+  grid: readAll(equip and (meter or status or thermometer or iaq or ups or point) and siteRef == site->id and equipRef != null)
     .find(e => e->ahu == true)
     .addMeta({checked: true, stale: false})
     .toGrid
+
+  selectedPoint: points[args->index]
 
   if (grid != null and p["curVal"] >= 10) do
     return {info: info, grid: grid}

--- a/syntaxes/axon.tmLanguage.json
+++ b/syntaxes/axon.tmLanguage.json
@@ -4,12 +4,14 @@
   "scopeName": "source.axon",
   "patterns": [
     { "include": "#comments" },
+    { "include": "#bracket-access" },
     { "include": "#strings" },
     { "include": "#refs" },
     { "include": "#numbers" },
     { "include": "#constants" },
     { "include": "#keywords" },
     { "include": "#dict-keys" },
+    { "include": "#haystack-tags" },
     { "include": "#operators" },
     { "include": "#method-calls" },
     { "include": "#function-calls" }
@@ -116,6 +118,40 @@
           "captures": {
             "1": { "name": "entity.name.function.axon" }
           }
+        }
+      ]
+    },
+    "haystack-tags": {
+      "patterns": [
+        {
+          "name": "support.type.haystack-tag.axon",
+          "match": "(?<![A-Za-z0-9_>.])\\b(?:ahu|equip|equipRef|iaq|meter|point|site|siteRef|status|thermometer|ups)\\b(?!\\s*(?:[:(]|->))"
+        }
+      ]
+    },
+    "bracket-access": {
+      "patterns": [
+        {
+          "name": "meta.bracket.access.axon",
+          "begin": "\\[",
+          "beginCaptures": {
+            "0": { "name": "punctuation.section.brackets.begin.axon" }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": { "name": "punctuation.section.brackets.end.axon" }
+          },
+          "patterns": [
+            { "include": "#strings" },
+            { "include": "#refs" },
+            { "include": "#numbers" },
+            { "include": "#constants" },
+            { "include": "#keywords" },
+            { "include": "#operators" },
+            { "include": "#method-calls" },
+            { "include": "#function-calls" },
+            { "include": "#haystack-tags" }
+          ]
         }
       ]
     }

--- a/test/axonGrammar.test.ts
+++ b/test/axonGrammar.test.ts
@@ -72,13 +72,21 @@ test("Axon TextMate grammar scopes real-shaped chained calls, keys, operators, a
   assertToken(scopedText, "addMeta", "entity.name.function.method.axon");
   assertToken(scopedText, "toGrid", "entity.name.function.method.axon");
 
-  for (const key of ["info", "title", "id", "dis", "name", "val", "key", "grid", "checked", "stale"]) {
+  for (const key of ["info", "title", "id", "dis", "name", "val", "key", "grid", "selectedPoint", "checked", "stale"]) {
     assertToken(scopedText, key, "variable.parameter.key.axon");
+  }
+
+  for (const tag of ["equip", "meter", "status", "thermometer", "iaq", "ups", "point", "siteRef", "equipRef"]) {
+    assertToken(scopedText, tag, "support.type.haystack-tag.axon");
   }
 
   for (const operator of ["=>", "->", "==", "!=", ">="]) {
     assertToken(scopedText, operator, "keyword.operator.axon");
   }
+
+  assertToken(scopedText, "[", "punctuation.section.brackets.begin.axon");
+  assertToken(scopedText, "]", "punctuation.section.brackets.end.axon");
+  assertToken(scopedText, "curVal", "string.quoted.double.axon");
 
   assertToken(scopedText, "@p:demo-site-123", "constant.other.reference.axon");
   assertToken(scopedText, "null", "constant.language.axon");
@@ -86,7 +94,6 @@ test("Axon TextMate grammar scopes real-shaped chained calls, keys, operators, a
   assertToken(scopedText, "false", "constant.language.axon");
   assertToken(scopedText, "na", "constant.language.axon");
   assertToken(scopedText, "10", "constant.numeric.axon");
-  assertToken(scopedText, "curVal", "string.quoted.double.axon");
 });
 
 function tokenizeLines(grammar: Awaited<ReturnType<typeof loadAxonGrammar>>, sourceLines: string[]): ScopedToken[] {


### PR DESCRIPTION
## Summary
- Add conservative TextMate scopes for common Haystack/filter tag identifiers.
- Add bracket access metadata and punctuation scopes while preserving quoted key string scopes.
- Extend the sanitized real-shape sample and grammar tests for `readAll(...)` filter tags, `p[\"curVal\"]`, and `points[args->index]`.

Refs #7

## Tests
- npm run test:grammar
- npm test
- git diff --check

## Notes
- Kept this to syntax-colour grammar/sample/test polish only; no parser or semantic expansion.