### PR TITLE
feat: add conservative Axon snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ This scaffold provides:
 - `samples/basic.axon` and `samples/real-shape.axon` as syntax-colour smoke files
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
 - a conservative pretty-printer with fixture-based tests
+- conservative Axon snippets for common verified patterns
+
+## Snippets
+
+Axon Wrangler contributes these `.axon` snippets:
+
+| Prefix | Expands to |
+| --- | --- |
+| `do` | `do` / body / `end` block |
+| `ifdo` | `if (...) do` / `else do` / `end` block |
+| `readHisNum` | `readAll(point and his and kind == "Number")` |
+| `readStreamLimit` | `readAllStream(...).limit(...).collect()` |
+| `hasFallback` | `dict.has("key") ? dict->key : fallback` |
+| `debugType` | `echo("value type: " + value.typeof)` |
+
+Unverified syntax is intentionally excluded. In particular, `try/catch` is deferred until the exact Axon syntax is confirmed against SkySpark docs or a live console.
 
 ## Pretty-print v0 limits
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
         "command": "axonWrangler.prettyPrint",
         "title": "Axon Wrangler: Pretty Print"
       }
+    ],
+    "snippets": [
+      {
+        "language": "axon",
+        "path": "./snippets/axon.json"
+      }
     ]
   },
   "scripts": {

--- a/snippets/axon.json
+++ b/snippets/axon.json
@@ -1,0 +1,42 @@
+{
+  "do/end block": {
+    "prefix": "do",
+    "body": [
+      "do",
+      "  ${1:// body}",
+      "end"
+    ],
+    "description": "Axon do/end block"
+  },
+  "if/do/else/end": {
+    "prefix": "ifdo",
+    "body": [
+      "if (${1:condition}) do",
+      "  ${2:// then}",
+      "else do",
+      "  ${3:// else}",
+      "end"
+    ],
+    "description": "Axon if/do/else/end block"
+  },
+  "read numeric history points": {
+    "prefix": "readHisNum",
+    "body": "readAll(point and his and kind == \"Number\")",
+    "description": "Read all numeric history points"
+  },
+  "readAllStream limit collect": {
+    "prefix": "readStreamLimit",
+    "body": "readAllStream(${1:filter}).limit(${2:100}).collect()",
+    "description": "Read records as a stream, limit, then collect"
+  },
+  "dict has fallback": {
+    "prefix": "hasFallback",
+    "body": "${1:dict}.has(\"${2:key}\") ? ${1:dict}->${2:key} : ${3:fallback}",
+    "description": "Check a dict key before reading it, with fallback"
+  },
+  "debug type": {
+    "prefix": "debugType",
+    "body": "echo(\"${1:value type}: \" + ${1:value}.typeof)",
+    "description": "Print the runtime type of a value while debugging"
+  }
+}

--- a/test/snippets.test.ts
+++ b/test/snippets.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+type Snippet = {
+  prefix: string;
+  body: string | string[];
+  description: string;
+};
+
+const packageJson = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8"));
+const snippets = JSON.parse(readFileSync(join(process.cwd(), "snippets", "axon.json"), "utf8")) as Record<string, Snippet>;
+
+test("package contributes Axon snippets", () => {
+  assert.deepEqual(packageJson.contributes.snippets, [
+    { language: "axon", path: "./snippets/axon.json" },
+  ]);
+});
+
+test("snippet pack contains only verified conservative Axon patterns", () => {
+  const expectedPrefixes = ["do", "ifdo", "readHisNum", "readStreamLimit", "hasFallback", "debugType"];
+  assert.deepEqual(Object.values(snippets).map((snippet) => snippet.prefix), expectedPrefixes);
+  assert.equal(JSON.stringify(snippets).includes("try"), false, "try/catch remains deferred until syntax is confirmed");
+});
+
+test("snippet bodies include useful placeholders and safe examples", () => {
+  assert.deepEqual(snippets["do/end block"].body, ["do", "  ${1:// body}", "end"]);
+  assert.equal(snippets["read numeric history points"].body, "readAll(point and his and kind == \"Number\")");
+  assert.equal(snippets["readAllStream limit collect"].body, "readAllStream(${1:filter}).limit(${2:100}).collect()");
+  assert.match(String(snippets["dict has fallback"].body), /\.has\("\$\{2:key\}"\)/);
+  assert.match(String(snippets["debug type"].body), /\.typeof/);
+});


### PR DESCRIPTION
Closes pipseedai/axon-wrangler#10

## Summary
- contributes a `.axon` VS Code snippet pack for verified conservative Axon patterns
- adds prefixes for `do`, `ifdo`, `readHisNum`, `readStreamLimit`, `hasFallback`, and `debugType`
- documents the snippet prefixes in README and explicitly defers unverified `try/catch` syntax
- adds tests that validate the package contribution and snippet pack contents

## Tests
- `npm test`