### PR TITLE
feat: add conservative Axon block indentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axon-wrangler",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axon-wrangler",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "devDependencies": {
         "@types/node": "^20.14.10",
         "@types/vscode": "^1.90.0",

--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -1,17 +1,69 @@
 /**
- * Conservative Axon pretty-printer v0.
+ * Conservative Axon pretty-printer.
  *
  * This intentionally does not parse Axon. Keep transformations text-preserving
- * and fixture-backed: remove trailing horizontal whitespace and ensure exactly
- * one final newline.
+ * and fixture-backed: normalize line endings, remove trailing horizontal
+ * whitespace, ensure exactly one final newline, and indent only obvious
+ * line-oriented do/end/else block boundaries.
  */
+const INDENT = "  ";
+
 export function prettyPrintAxon(source: string): string {
-  const withoutTrailingWhitespace = source
+  const normalizedLines = source
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
     .split("\n")
-    .map((line) => line.replace(/[\t ]+$/u, ""))
-    .join("\n");
+    .map((line) => line.replace(/[\t ]+$/u, ""));
 
-  return `${withoutTrailingWhitespace.replace(/\n*$/u, "")}\n`;
+  const withoutTrailingBlankLines = dropTrailingBlankLines(normalizedLines);
+  const indented = indentObviousBlocks(withoutTrailingBlankLines);
+
+  return `${indented.join("\n")}\n`;
+}
+
+function dropTrailingBlankLines(lines: string[]): string[] {
+  const result = [...lines];
+  while (result.length > 0 && result[result.length - 1] === "") {
+    result.pop();
+  }
+  return result;
+}
+
+function indentObviousBlocks(lines: string[]): string[] {
+  let depth = 0;
+
+  return lines.map((line) => {
+    if (line.trim() === "") {
+      return "";
+    }
+
+    const trimmed = line.trimStart();
+    if (startsObviousBlockContinuation(trimmed)) {
+      depth = Math.max(0, depth - 1);
+    }
+
+    const formatted = `${INDENT.repeat(depth)}${trimmed}`;
+
+    if (startsElseBlock(trimmed) || endsWithLineOrientedDo(trimmed)) {
+      depth += 1;
+    }
+
+    return formatted;
+  });
+}
+
+function startsObviousBlockContinuation(trimmed: string): boolean {
+  return startsEndBlock(trimmed) || startsElseBlock(trimmed);
+}
+
+function startsEndBlock(trimmed: string): boolean {
+  return /^end(?:\b|\))/u.test(trimmed);
+}
+
+function startsElseBlock(trimmed: string): boolean {
+  return /^else\b/u.test(trimmed);
+}
+
+function endsWithLineOrientedDo(trimmed: string): boolean {
+  return /\bdo\s*$/u.test(trimmed);
 }

--- a/test/fixtures/comments-preserved/expected.axon
+++ b/test/fixtures/comments-preserved/expected.axon
@@ -1,0 +1,4 @@
+read(site).map(s => do
+  // keep comment text do/end/else
+  note: "do not treat end inside string"
+end)

--- a/test/fixtures/comments-preserved/input.axon
+++ b/test/fixtures/comments-preserved/input.axon
@@ -1,0 +1,4 @@
+read(site).map(s => do
+// keep comment text do/end/else
+note: "do not treat end inside string"
+end)

--- a/test/fixtures/if-else-end/expected.axon
+++ b/test/fixtures/if-else-end/expected.axon
@@ -1,0 +1,5 @@
+if (site.has("area")) do
+  area: site->area
+else do
+  area: na
+end

--- a/test/fixtures/if-else-end/input.axon
+++ b/test/fixtures/if-else-end/input.axon
@@ -1,0 +1,5 @@
+if (site.has("area")) do
+area: site->area
+else do
+area: na
+end

--- a/test/fixtures/inline-one-liners-preserved/expected.axon
+++ b/test/fixtures/inline-one-liners-preserved/expected.axon
@@ -1,0 +1,1 @@
+readAll(point).map(p => if (p.has("cur")) p->cur else na)

--- a/test/fixtures/inline-one-liners-preserved/input.axon
+++ b/test/fixtures/inline-one-liners-preserved/input.axon
@@ -1,0 +1,1 @@
+readAll(point).map(p => if (p.has("cur")) p->cur else na)

--- a/test/fixtures/nested-do-end/expected.axon
+++ b/test/fixtures/nested-do-end/expected.axon
@@ -1,0 +1,7 @@
+readAll(site).map(site => do
+  name: site->dis
+  points: readAll(point and siteRef == site->id).map(p => do
+    id: p->id
+    dis: p->dis
+  end)
+end)

--- a/test/fixtures/nested-do-end/input.axon
+++ b/test/fixtures/nested-do-end/input.axon
@@ -1,0 +1,7 @@
+readAll(site).map(site => do
+name: site->dis
+points: readAll(point and siteRef == site->id).map(p => do
+id: p->id
+dis: p->dis
+end)
+end)


### PR DESCRIPTION
Closes pipseedai/axon-wrangler#11

## Summary
- extends the conservative pretty-printer with fixture-backed two-space indentation for obvious line-oriented `do` / `else` / `end` boundaries
- covers nested `do/end`, `if/else/end`, comment/string preservation inside blocks, and inline one-liners that should stay unchanged
- updates README formatter limitations to spell out the safe subset and deferred semantic rewrites

## Tests
- `npm test`