### PR TITLE
feat: add curated Axon hover help

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ This scaffold provides:
 - `samples/basic.axon` and `samples/real-shape.axon` as syntax-colour smoke files
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
 - a conservative pretty-printer with fixture-based tests
+- curated hover help for selected Axon functions and gotchas
+
+## Hover support
+
+Axon Wrangler registers a conservative hover provider for `.axon` files. Hover content is short, source-safe, and intentionally limited to terms already captured in the Axon notes:
+
+- `debugType`
+- `readAll`
+- `readAllStream`
+- `parseFilter`
+- `filterToFunc`
+- `fold`
+- `na`
+- `toSpan`
+
+The hover provider is not a language server and does not inspect SkySpark project state. It only surfaces compact reminders for known functions and gotchas.
 
 ## Pretty-print v0 limits
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { axonHoverProvider } from "./hovers";
 import { prettyPrintAxon } from "./prettyPrint";
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -28,7 +29,9 @@ export function activate(context: vscode.ExtensionContext): void {
     });
   });
 
-  context.subscriptions.push(disposable);
+  const hoverDisposable = vscode.languages.registerHoverProvider("axon", axonHoverProvider);
+
+  context.subscriptions.push(disposable, hoverDisposable);
 }
 
 export function deactivate(): void {

--- a/src/hoverData.ts
+++ b/src/hoverData.ts
@@ -1,0 +1,45 @@
+export type AxonHoverEntry = {
+  label: string;
+  detail: string;
+  example?: string;
+};
+
+export const AXON_HOVERS: Record<string, AxonHoverEntry> = {
+  debugType: {
+    label: "debugType",
+    detail: "Runtime type string. Use this for Axon type checks instead of JavaScript-style typeof.",
+    example: 'val.debugType == "sys::Date"',
+  },
+  readAll: {
+    label: "readAll(filter[, opts])",
+    detail: "Reads matching records into a grid. Use opts such as {limit: 1000}; stream-only methods like limit() belong on readAllStream().",
+    example: 'readAll(point and his and kind == "Number", {limit: 1000})',
+  },
+  readAllStream: {
+    label: "readAllStream(filter)",
+    detail: "Streams matching records. Use stream methods like limit(...).collect() here, not on readAll(...).",
+    example: 'readAllStream(point and his).limit(10).collect()',
+  },
+  parseFilter: {
+    label: "parseFilter(str)",
+    detail: "Parses a filter string into a filter expression for programmatic filtering.",
+    example: 'parseFilter("point and his")',
+  },
+  filterToFunc: {
+    label: "filterToFunc(filter)",
+    detail: "Converts a filter expression into a predicate function. Useful when applying Haystack filters in code.",
+  },
+  fold: {
+    label: "fold",
+    detail: "Reduction/aggregation pattern for collections. Prefer it when accumulating a value across a list or grid-derived list.",
+  },
+  na: {
+    label: "na()",
+    detail: "Represents not-available. It is distinct from null, so do not treat na() and null as interchangeable.",
+  },
+  toSpan: {
+    label: "toSpan(...) —— named span or explicit dates",
+    detail: 'Known named strings include "today", "yesterday", "thisWeek", "lastWeek", "thisMonth", "lastMonth", "thisQuarter", "lastQuarter", "thisYear", and "lastYear". Rolling strings like "last7days" are not valid.',
+    example: "toSpan(today() - 90day, today())",
+  },
+};

--- a/src/hovers.ts
+++ b/src/hovers.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+import { AXON_HOVERS } from "./hoverData";
+
+const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_]*/;
+
+export function getAxonHoverMarkdown(word: string): vscode.MarkdownString | undefined {
+  const entry = AXON_HOVERS[word];
+  if (!entry) return undefined;
+
+  const markdown = new vscode.MarkdownString(undefined, true);
+  markdown.isTrusted = false;
+  markdown.appendMarkdown(`**${entry.label}**\n\n${entry.detail}`);
+  if (entry.example) {
+    markdown.appendCodeblock(entry.example, "axon");
+  }
+  return markdown;
+}
+
+export const axonHoverProvider: vscode.HoverProvider = {
+  provideHover(document, position) {
+    const range = document.getWordRangeAtPosition(position, WORD_PATTERN);
+    if (!range) return undefined;
+
+    const word = document.getText(range);
+    const markdown = getAxonHoverMarkdown(word);
+    return markdown ? new vscode.Hover(markdown, range) : undefined;
+  },
+};

--- a/test/hovers.test.ts
+++ b/test/hovers.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AXON_HOVERS } from "../src/hoverData";
+
+const expectedTerms = [
+  "debugType",
+  "readAll",
+  "readAllStream",
+  "parseFilter",
+  "filterToFunc",
+  "fold",
+  "na",
+  "toSpan",
+];
+
+test("curated Axon hover dictionary covers the initial source-safe terms", () => {
+  assert.deepEqual(Object.keys(AXON_HOVERS).sort(), expectedTerms.sort());
+});
+
+test("Axon hovers stay concise and source-safe", () => {
+  for (const [term, hover] of Object.entries(AXON_HOVERS)) {
+    assert.ok(hover.label.includes(term) || hover.label.toLowerCase().includes(term.toLowerCase()));
+    assert.ok(hover.detail.length > 20, `${term} detail should be useful`);
+    assert.ok(hover.detail.length < 280, `${term} detail should stay short`);
+    assert.doesNotMatch(hover.detail, /probably|maybe|unknown/i, `${term} should avoid speculative wording`);
+  }
+});
+
+test("hover content includes known gotchas for risky Axon terms", () => {
+  assert.match(AXON_HOVERS.debugType.detail, /instead of.*typeof/i);
+  assert.match(AXON_HOVERS.readAll.detail, /readAllStream/i);
+  assert.match(AXON_HOVERS.readAllStream.detail, /limit/i);
+  assert.match(AXON_HOVERS.na.detail, /distinct from null/i);
+  assert.match(AXON_HOVERS.toSpan.detail, /last7days.*not valid/i);
+});


### PR DESCRIPTION
Closes #15

## Summary
- registers a conservative hover provider for `.axon` files
- adds short source-safe hover content for `debugType`, `readAll`, `readAllStream`, `parseFilter`, `filterToFunc`, `fold`, `na`, and `toSpan`
- keeps hover dictionary data testable without requiring the VS Code runtime
- documents hover support and its limits in README

## Tests
- `npm test`
