### PR TITLE
feat: add native Axon format providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This scaffold provides:
 - conservative TextMate syntax colouring for comments, strings, numbers, refs, keywords/block words, constants, operators/arrows, dict/tag keys, and function/method-ish calls
 - `samples/basic.axon` and `samples/real-shape.axon` as syntax-colour smoke files
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
+- native VS Code Format Document / Format Selection providers for `.axon`
 - a conservative pretty-printer with fixture-based tests
 
 ## Pretty-print v0 limits
@@ -64,6 +65,23 @@ This verifies emitted TextMate scopes for representative comments, strings, numb
 5. Confirm the active VS Code theme visibly distinguishes the scoped shapes that `npm run test:grammar` already verifies: comments, strings, numbers, refs such as `@p:demo-site-123`, block words such as `do`/`end`, constants such as `true`/`false`/`null`, operators/arrows such as `=>`/`->`/`==`, dict/tag keys before `:`, and chained method-ish calls such as `.sort(...)`/`.addMeta(...)`/`.toGrid`.
 
 The v0 grammar is intentionally conservative. It does not fully parse Axon or attempt semantic highlighting; it only provides stable TextMate scopes for the obvious lexical shapes covered by the automated tokenization samples. Visual theme contrast remains a manual VS Code check.
+
+## Native formatting support
+
+Axon Wrangler wires the same conservative pretty-printer into both:
+
+- command palette: `Axon Wrangler: Pretty Print`
+- native VS Code actions: `Format Document` and `Format Selection`
+
+The command remains useful when you want Axon Wrangler's explicit command name. The native formatting providers are for normal editor workflows and format-on-save setups. Both paths intentionally share the same conservative formatting behavior.
+
+Manual Extension Development Host check:
+
+1. Launch the Extension Development Host with `F5`.
+2. Open a `.axon` document with trailing whitespace or extra trailing blank lines.
+3. Run `Format Document` and confirm the whole file is normalized.
+4. Select a smaller range, run `Format Selection`, and confirm only the selected range is normalized.
+5. Run `Axon Wrangler: Pretty Print` and confirm the command still works.
 
 ## Pretty-print testing
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,10 @@
 import * as vscode from "vscode";
-import { prettyPrintAxon } from "./prettyPrint";
+import {
+  axonDocumentFormattingProvider,
+  axonRangeFormattingProvider,
+  buildFormattingTextEdit,
+  fullDocumentRange,
+} from "./formatting";
 
 export function activate(context: vscode.ExtensionContext): void {
   const disposable = vscode.commands.registerCommand("axonWrangler.prettyPrint", async () => {
@@ -15,27 +20,32 @@ export function activate(context: vscode.ExtensionContext): void {
     const targetRange = selection.isEmpty
       ? fullDocumentRange(document)
       : new vscode.Range(selection.start, selection.end);
-    const original = document.getText(targetRange);
-    const formatted = prettyPrintAxon(original);
+    const edits = buildFormattingTextEdit(document, targetRange);
 
-    if (formatted === original) {
+    if (edits.length === 0) {
       vscode.window.showInformationMessage("Axon Wrangler: already pretty enough.");
       return;
     }
 
     await editor.edit((editBuilder) => {
-      editBuilder.replace(targetRange, formatted);
+      for (const edit of edits) {
+        editBuilder.replace(edit.range, edit.newText);
+      }
     });
   });
 
-  context.subscriptions.push(disposable);
+  const documentFormatter = vscode.languages.registerDocumentFormattingEditProvider(
+    "axon",
+    axonDocumentFormattingProvider,
+  );
+  const rangeFormatter = vscode.languages.registerDocumentRangeFormattingEditProvider(
+    "axon",
+    axonRangeFormattingProvider,
+  );
+
+  context.subscriptions.push(disposable, documentFormatter, rangeFormatter);
 }
 
 export function deactivate(): void {
   // Nothing to clean up yet.
-}
-
-function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
-  const lastLine = document.lineAt(document.lineCount - 1);
-  return new vscode.Range(new vscode.Position(0, 0), lastLine.range.end);
 }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+import { prettyPrintAxon } from "./prettyPrint";
+
+export function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
+  const lastLine = document.lineAt(document.lineCount - 1);
+  return new vscode.Range(new vscode.Position(0, 0), lastLine.range.end);
+}
+
+export function buildFullDocumentTextEdit(document: vscode.TextDocument): vscode.TextEdit[] {
+  const range = fullDocumentRange(document);
+  return buildFormattingTextEdit(document, range);
+}
+
+export function buildFormattingTextEdit(document: vscode.TextDocument, range: vscode.Range): vscode.TextEdit[] {
+  const original = document.getText(range);
+  const formatted = prettyPrintAxon(original);
+  return formatted === original ? [] : [vscode.TextEdit.replace(range, formatted)];
+}
+
+export const axonDocumentFormattingProvider: vscode.DocumentFormattingEditProvider = {
+  provideDocumentFormattingEdits(document) {
+    return buildFullDocumentTextEdit(document);
+  },
+};
+
+export const axonRangeFormattingProvider: vscode.DocumentRangeFormattingEditProvider = {
+  provideDocumentRangeFormattingEdits(document, range) {
+    return buildFormattingTextEdit(document, range);
+  },
+};

--- a/test/formattingProvider.test.ts
+++ b/test/formattingProvider.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prettyPrintAxon } from "../src/prettyPrint";
+
+function providerAdjacentFormat(text: string): string {
+  return prettyPrintAxon(text);
+}
+
+test("Format Document path uses the conservative pretty-printer result", () => {
+  const input = "readAll(point)  \r\n\r\n";
+  const expected = "readAll(point)\n";
+
+  assert.equal(providerAdjacentFormat(input), expected);
+});
+
+test("Format Selection path can format a selected fragment without semantic rewrites", () => {
+  const selected = "  echo(\"hello\")  \n\n\n";
+  const expected = "  echo(\"hello\")\n";
+
+  assert.equal(providerAdjacentFormat(selected), expected);
+});


### PR DESCRIPTION
Closes #12

## Summary
- registers native VS Code Format Document and Format Selection providers for Axon
- keeps the explicit `Axon Wrangler: Pretty Print` command available
- shares the same conservative pretty-printer path between command and native formatting actions
- documents command vs native formatting behavior and manual Extension Development Host checks

## Tests
- `npm test`
