### PR TITLE
feat: add conservative Axon diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ This scaffold provides:
 - `samples/basic.axon` and `samples/real-shape.axon` as syntax-colour smoke files
 - `Axon Wrangler: Pretty Print` command (`axonWrangler.prettyPrint`)
 - a conservative pretty-printer with fixture-based tests
+- lightweight diagnostics for common Axon footguns
+
+## Diagnostics
+
+Axon Wrangler publishes conservative warning diagnostics for obvious Axon footguns:
+
+- `typeof` usage: use `debugType` for runtime type checks
+- `.toLower()` / `.toUpper()`: use Axon `lower()` / `upper()`
+- `dict.get("key", fallback)`: handle fallback explicitly after `get()`
+- `readAll(...).limit(...)`: use `readAllStream(...).limit(...).collect()` or a DB limit option
+- tautological filters such as `siteRef == siteRef` or `equipRef == equipRef`
+
+The diagnostics are regex/token checks, not a full Axon parser. They intentionally skip matches in `//` comments and quoted strings, and they should stay limited to high-confidence warnings.
 
 ## Pretty-print v0 limits
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,105 @@
+export type AxonDiagnosticCode =
+  | "typeof-debugType"
+  | "string-case-func"
+  | "dict-get-fallback"
+  | "readAll-limit"
+  | "filter-tautology";
+
+export type AxonDiagnosticFinding = {
+  code: AxonDiagnosticCode;
+  message: string;
+  start: number;
+  end: number;
+};
+
+type Rule = {
+  code: AxonDiagnosticCode;
+  pattern: RegExp;
+  message: (match: RegExpExecArray) => string;
+  range?: (match: RegExpExecArray) => [number, number];
+};
+
+const RULES: Rule[] = [
+  {
+    code: "typeof-debugType",
+    pattern: /\btypeof\b/g,
+    message: () => "Axon does not use JavaScript typeof; use debugType for runtime type checks.",
+  },
+  {
+    code: "string-case-func",
+    pattern: /\.to(Lower|Upper)\s*\(/g,
+    message: (match) => `Axon strings use ${match[1] === "Lower" ? "lower" : "upper"}(), not ${match[0].trim()}.`,
+  },
+  {
+    code: "dict-get-fallback",
+    pattern: /\b[A-Za-z_][A-Za-z0-9_]*\.get\s*\(\s*(["'`])[^"'`]+\1\s*,/g,
+    message: () => "Axon Dict.get does not use a fallback argument; handle fallback explicitly after get().",
+  },
+  {
+    code: "readAll-limit",
+    pattern: /\breadAll\s*\([^\n)]*\)\s*\.limit\s*\(/g,
+    message: () => "readAll() returns a grid; use readAllStream(...).limit(...).collect() or pass a DB limit option.",
+  },
+  {
+    code: "filter-tautology",
+    pattern: /\b(siteRef|equipRef|pointRef|spaceRef)\s*==\s*\1\b/g,
+    message: (match) => `Suspicious filter tautology: ${match[1]} is compared with itself.`,
+  },
+];
+
+export function findAxonDiagnostics(text: string): AxonDiagnosticFinding[] {
+  const findings: AxonDiagnosticFinding[] = [];
+
+  for (const rule of RULES) {
+    for (const match of text.matchAll(rule.pattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      if (isIgnoredMatch(text, start)) continue;
+
+      const [rangeStart, rangeEnd] = rule.range ? rule.range(match) : [start, end];
+      findings.push({
+        code: rule.code,
+        message: rule.message(match),
+        start: rangeStart,
+        end: rangeEnd,
+      });
+    }
+  }
+
+  return findings.sort((a, b) => a.start - b.start || a.end - b.end);
+}
+
+function isIgnoredMatch(text: string, offset: number): boolean {
+  return isAfterLineComment(text, offset) || isInsideQuotedString(text, offset);
+}
+
+function isAfterLineComment(text: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+  const commentStart = text.indexOf("//", lineStart);
+  return commentStart !== -1 && commentStart < offset;
+}
+
+function isInsideQuotedString(text: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+  let quote: string | undefined;
+  let escaped = false;
+
+  for (let index = lineStart; index < offset; index += 1) {
+    const char = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+  }
+
+  return quote !== undefined;
+}

--- a/src/diagnosticsProvider.ts
+++ b/src/diagnosticsProvider.ts
@@ -1,0 +1,38 @@
+import * as vscode from "vscode";
+import { findAxonDiagnostics } from "./diagnostics";
+
+export function registerAxonDiagnostics(context: vscode.ExtensionContext): void {
+  const collection = vscode.languages.createDiagnosticCollection("axon-wrangler");
+
+  const refresh = (document: vscode.TextDocument) => {
+    if (!isAxonDocument(document)) return;
+
+    const diagnostics = findAxonDiagnostics(document.getText()).map((finding) => {
+      const diagnostic = new vscode.Diagnostic(
+        new vscode.Range(document.positionAt(finding.start), document.positionAt(finding.end)),
+        finding.message,
+        vscode.DiagnosticSeverity.Warning,
+      );
+      diagnostic.code = finding.code;
+      diagnostic.source = "Axon Wrangler";
+      return diagnostic;
+    });
+
+    collection.set(document.uri, diagnostics);
+  };
+
+  for (const document of vscode.workspace.textDocuments) {
+    refresh(document);
+  }
+
+  context.subscriptions.push(
+    collection,
+    vscode.workspace.onDidOpenTextDocument(refresh),
+    vscode.workspace.onDidChangeTextDocument((event) => refresh(event.document)),
+    vscode.workspace.onDidCloseTextDocument((document) => collection.delete(document.uri)),
+  );
+}
+
+function isAxonDocument(document: vscode.TextDocument): boolean {
+  return document.languageId === "axon" || document.fileName.endsWith(".axon");
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { registerAxonDiagnostics } from "./diagnosticsProvider";
 import { prettyPrintAxon } from "./prettyPrint";
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -27,6 +28,8 @@ export function activate(context: vscode.ExtensionContext): void {
       editBuilder.replace(targetRange, formatted);
     });
   });
+
+  registerAxonDiagnostics(context);
 
   context.subscriptions.push(disposable);
 }

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findAxonDiagnostics } from "../src/diagnostics";
+
+function codes(text: string): string[] {
+  return findAxonDiagnostics(text).map((finding) => finding.code);
+}
+
+test("diagnostics flag conservative Axon footguns", () => {
+  const text = [
+    'x: val.typeof == "Str"',
+    'name.toLower()',
+    'name.toUpper()',
+    'dict.get("missing", "fallback")',
+    'readAll(point and his).limit(10)',
+    'readAll(site).sort("dis")',
+    'siteRef == siteRef',
+  ].join("\n");
+
+  assert.deepEqual(codes(text), [
+    "typeof-debugType",
+    "string-case-func",
+    "string-case-func",
+    "dict-get-fallback",
+    "readAll-limit",
+    "filter-tautology",
+  ]);
+});
+
+test("diagnostics messages name the safer Axon shape", () => {
+  const diagnostics = findAxonDiagnostics(
+    'typeof x\nname.toLower()\ndict.get("x", 1)\nreadAll(point).limit(3)\nequipRef == equipRef',
+  );
+  const messages = diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+
+  assert.match(messages, /debugType/);
+  assert.match(messages, /lower\(\)/);
+  assert.match(messages, /fallback explicitly/);
+  assert.match(messages, /readAllStream/);
+  assert.match(messages, /compared with itself/);
+});
+
+test("diagnostics skip comments and quoted strings", () => {
+  const text = [
+    '// typeof name.toLower() dict.get("x", 1) readAll(point).limit(1)',
+    'msg: "typeof name.toUpper() siteRef == siteRef"',
+    'safe: debugType',
+  ].join("\n");
+
+  assert.deepEqual(findAxonDiagnostics(text), []);
+});


### PR DESCRIPTION
Closes #9

## Summary
- adds a lightweight diagnostic collection for Axon documents
- warns on high-confidence Axon footguns: `typeof`, `.toLower()` / `.toUpper()`, `dict.get("key", fallback)`, `readAll(...).limit(...)`, and tautological ref filters
- keeps pure diagnostic finding logic testable without requiring the VS Code runtime
- documents rules and conservative limits in README

## Tests
- `npm test`
